### PR TITLE
webrtc improvements, support for video

### DIFF
--- a/base-displayaudio/Dockerfile
+++ b/base-displayaudio/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:bionic
 
-RUN apt-get -y update
-
 # Adapted from https://github.com/radiokit/docker-gstreamer/blob/master/Dockerfile
+RUN apt-get -y update
 
 # Install compiler etc.
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -17,7 +16,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
   git-core \
   build-essential \
   gettext \
-  pulseaudio
+  pulseaudio \
+  gtk-doc-tools
 
 # Install dependencies necessary to build our custom GStreamer build
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -32,17 +32,23 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
   libpulse-dev \
   libopus-dev \
   libgirepository1.0-dev \
-  libnice-dev \
   libsrtp2-dev \
   libvpx-dev \
-  gtk-doc-tools
+  libx11-dev \
+  libxv-dev \
+  libxt-dev \
+  #libx264-dev \
+  libgnutls28-dev \
+  python-gi-dev \
+  python-dev
 
-ARG GST_VERSION=1.14.4
+
+ARG GIT_BRANCH=master
 
 # Fetch and build GStreamer
-RUN git clone -b $GST_VERSION --depth 1 git://anongit.freedesktop.org/git/gstreamer/gstreamer && \
+RUN git clone -b $GIT_BRANCH --depth 1 git://anongit.freedesktop.org/git/gstreamer/gstreamer && \
 cd gstreamer && \
-git checkout $GST_VERSION && \
+git checkout $GIT_BRANCH && \
 ./autogen.sh --prefix=/usr --disable-gtk-doc && \
 make -j`nproc` && \
 make install && \
@@ -50,21 +56,21 @@ cd .. && \
 rm -rvf /gstreamer
 
 # Fetch and build gst-plugins-base
-RUN git clone -b $GST_VERSION --depth 1 git://anongit.freedesktop.org/git/gstreamer/gst-plugins-base && \
+RUN git clone -b $GIT_BRANCH --depth 1 git://anongit.freedesktop.org/git/gstreamer/gst-plugins-base && \
 cd gst-plugins-base && \
-git checkout $GST_VERSION && \
+git checkout $GIT_BRANCH && \
 ./autogen.sh --prefix=/usr \
 --disable-gtk-doc \
 --disable-adder \
 --disable-app \
---disable-videoconvert \
+#--disable-videoconvert \
 --disable-gio \
 --disable-subparse \
 #--disable-tcp \
---disable-videotestsrc \
+#--disable-videotestsrc \
 --disable-videorate \
 --disable-videoscale \
---disable-x \
+#--disable-x \
 --disable-xvideo \
 --disable-xshm \
 --disable-alsa \
@@ -78,18 +84,23 @@ make install && \
 cd .. && \
 rm -rvf /gst-plugins-base
 
+
 # libnice
-RUN git clone https://github.com/libnice/libnice.git \
+ARG LIB_NICE_VERSION=0.1.15
+
+RUN git clone -b $LIB_NICE_VERSION git://anongit.freedesktop.org/libnice/libnice \
 && cd libnice \
+&& git checkout $LIB_NICE_VERSION \
 && ./autogen.sh --prefix=/usr --with-gstreamer --enable-static --enable-static-plugins --enable-shared --without-gstreamer-0.10 --disable-gtk-doc --enable-compile-warnings=no \
 && make install && \
 cd .. && \
-rm -rvf /libnic
+rm -rvf /libnice
+
 
 # Fetch and build gst-plugins-good
-RUN git clone -b $GST_VERSION --depth 1 git://anongit.freedesktop.org/git/gstreamer/gst-plugins-good && \
+RUN git clone -b $GIT_BRANCH --depth 1 git://anongit.freedesktop.org/git/gstreamer/gst-plugins-good && \
 cd gst-plugins-good && \
-git checkout $GST_VERSION && \
+git checkout $GIT_BRANCH && \
 ./autogen.sh --prefix=/usr \
 --disable-gtk-doc \
 --disable-alpha \
@@ -125,7 +136,7 @@ git checkout $GST_VERSION && \
 --disable-osx_audio \
 --disable-osx_video \
 --disable-gst_v4l2 \
---disable-x \
+#--disable-x \
 --disable-aalib \
 --disable-aalibtest \
 --disable-cairo \
@@ -145,12 +156,12 @@ cd .. && \
 rm -rvf /gst-plugins-good
 
 # Fetch and build gst-plugins-bad
-#RUN git clone -b $GST_VERSION --depth 1 git://anongit.freedesktop.org/git/gstreamer/gst-plugins-bad && \
+#RUN git clone -b $GIT_BRANCH --depth 1 git://anongit.freedesktop.org/git/gstreamer/gst-plugins-bad && \
 #cd gst-plugins-bad && \
-#git checkout $GST_VERSION && \
-RUN git clone -b fixed-port --depth 1 git://github.com/ikreymer/gst-plugins-bad.git && \
+#git checkout $GIT_BRANCH && \
+RUN git clone -b webrtc-port-range --depth 1 https://gitlab.freedesktop.org/ikreymer/gst-plugins-bad.git && \
 cd gst-plugins-bad && \
-git checkout fixed-port && \
+git checkout webrtc-port-range && \
 ./autogen.sh --prefix=/usr \
 --disable-gtk-doc \
 --disable-accurip \
@@ -290,12 +301,13 @@ git checkout fixed-port && \
 make -j`nproc` && \
 make install && \
 cd .. && \
-rm -rvf /gst-plugins-bad
+rm -rvf /gst-plugins-bad && echo ""
+
 
 # Fetch and build gst-plugins-ugly
-RUN git clone -b $GST_VERSION --depth 1 git://anongit.freedesktop.org/git/gstreamer/gst-plugins-ugly && \
+RUN git clone -b $GIT_BRANCH --depth 1 git://anongit.freedesktop.org/git/gstreamer/gst-plugins-ugly && \
 cd gst-plugins-ugly && \
-git checkout $GST_VERSION && \
+git checkout $GIT_BRANCH && \
 ./autogen.sh --prefix=/usr \
 --disable-gtk-doc \
 --disable-asfdemux \
@@ -309,20 +321,22 @@ git checkout $GST_VERSION && \
 --disable-cdio \
 --disable-dvdread \
 --disable-sidplay \
---disable-x264 && \
+--disable-x264 \
+&& \
 make -j`nproc` && \
 make install && \
 cd .. && \
 rm -rvf /gst-plugins-ugly
 
-RUN apt-get update && apt-get install -qyy python-gi-dev python-dev
+
+ARG GST_PY_VERSION=1.14
 
 # install gst-python
-RUN git clone -b $GST_VERSION --depth 1 git://anongit.freedesktop.org/git/gstreamer/gst-python && \
+RUN git clone -b $GST_PY_VERSION --depth 1 git://anongit.freedesktop.org/git/gstreamer/gst-python && \
 cd gst-python && \
-git checkout $GST_VERSION && \
+git checkout $GST_PY_VERSION && \
 ./autogen.sh --prefix=/usr && \
-make && \
+make -j`nproc` && \
 make install && \
 cd .. && \
 rm -rvf /gst-python

--- a/base-displayaudio/Dockerfile
+++ b/base-displayaudio/Dockerfile
@@ -145,9 +145,12 @@ cd .. && \
 rm -rvf /gst-plugins-good
 
 # Fetch and build gst-plugins-bad
-RUN git clone -b $GST_VERSION --depth 1 git://anongit.freedesktop.org/git/gstreamer/gst-plugins-bad && \
+#RUN git clone -b $GST_VERSION --depth 1 git://anongit.freedesktop.org/git/gstreamer/gst-plugins-bad && \
+#cd gst-plugins-bad && \
+#git checkout $GST_VERSION && \
+RUN git clone -b fixed-port --depth 1 git://github.com/ikreymer/gst-plugins-bad.git && \
 cd gst-plugins-bad && \
-git checkout $GST_VERSION && \
+git checkout fixed-port && \
 ./autogen.sh --prefix=/usr \
 --disable-gtk-doc \
 --disable-accurip \

--- a/vnc-webrtc-audio/app/signaling-server.py
+++ b/vnc-webrtc-audio/app/signaling-server.py
@@ -30,6 +30,8 @@ options = parser.parse_args(sys.argv[1:])
 ADDR_PORT = (options.addr, options.port)
 KEEPALIVE_TIMEOUT = options.keepalive_timeout
 
+port_msg = None
+
 ############### Global data ###############
 
 # Format: {uid: (Peer WebSocketServerProtocol,
@@ -114,7 +116,7 @@ async def remove_peer(uid):
 ############### Handler functions ###############
 
 async def connection_handler(ws, uid):
-    global peers, sessions, rooms
+    global peers, sessions, rooms, port_msg
     raddr = ws.remote_address
     peer_status = None
     peers[uid] = [ws, raddr, peer_status]
@@ -180,6 +182,11 @@ async def connection_handler(ws, uid):
             sessions[uid] = callee_id
             peers[callee_id][2] = 'session'
             sessions[callee_id] = uid
+
+            if port_msg:
+                print('Signaling send port msg: ', port_msg)
+                await ws.send(port_msg)
+                port_msg = None
         # Requested joining or creation of a room
         elif msg.startswith('ROOM'):
             print('Signaling server: {!r} command {!r}'.format(uid, msg))
@@ -207,6 +214,11 @@ async def connection_handler(ws, uid):
                 msg = 'ROOM_PEER_JOINED {}'.format(uid)
                 print('Signaling server: room {}: {} -> {}: {}'.format(room_id, uid, pid, msg))
                 await wsp.send(msg)
+
+        elif msg.startswith('PORT'):
+            port_msg = msg
+            print('Signaling server: got port msg', port_msg)
+
         else:
             print('Signaling server: Ignoring unknown message {!r} from {!r}'.format(msg, uid))
 

--- a/vnc-webrtc-audio/app/signaling-server.py
+++ b/vnc-webrtc-audio/app/signaling-server.py
@@ -30,8 +30,6 @@ options = parser.parse_args(sys.argv[1:])
 ADDR_PORT = (options.addr, options.port)
 KEEPALIVE_TIMEOUT = options.keepalive_timeout
 
-port_msg = None
-
 ############### Global data ###############
 
 # Format: {uid: (Peer WebSocketServerProtocol,
@@ -116,7 +114,7 @@ async def remove_peer(uid):
 ############### Handler functions ###############
 
 async def connection_handler(ws, uid):
-    global peers, sessions, rooms, port_msg
+    global peers, sessions, rooms
     raddr = ws.remote_address
     peer_status = None
     peers[uid] = [ws, raddr, peer_status]
@@ -182,11 +180,6 @@ async def connection_handler(ws, uid):
             sessions[uid] = callee_id
             peers[callee_id][2] = 'session'
             sessions[callee_id] = uid
-
-            if port_msg:
-                print('Signaling send port msg: ', port_msg)
-                await ws.send(port_msg)
-                port_msg = None
         # Requested joining or creation of a room
         elif msg.startswith('ROOM'):
             print('Signaling server: {!r} command {!r}'.format(uid, msg))
@@ -214,11 +207,6 @@ async def connection_handler(ws, uid):
                 msg = 'ROOM_PEER_JOINED {}'.format(uid)
                 print('Signaling server: room {}: {} -> {}: {}'.format(room_id, uid, pid, msg))
                 await wsp.send(msg)
-
-        elif msg.startswith('PORT'):
-            port_msg = msg
-            print('Signaling server: got port msg', port_msg)
-
         else:
             print('Signaling server: Ignoring unknown message {!r} from {!r}'.format(msg, uid))
 
@@ -293,3 +281,4 @@ logger.addHandler(logging.StreamHandler())
 
 asyncio.get_event_loop().run_until_complete(wsd)
 asyncio.get_event_loop().run_forever()
+


### PR DESCRIPTION
- update base image to use latest gstreamer with gst-plugins-bad patch allowing port range selection, and plugins that support video
- include both audio and audio/video pipelines, use video if WEBRTC_VIDEO is set
- set rtp port (using patched webrtcbin plugin) to RTP_PORT (default 10235)
- add minimal candidate filtering, only send tcp listener or udp 'typ host' candidates
- remove unused receive callbacks, as pipeline is send-only