### PR TITLE
broser entrypoint: improvements for loading CA cert:

### DIFF
--- a/browser_entrypoint.sh
+++ b/browser_entrypoint.sh
@@ -8,6 +8,19 @@ if [[ -n "$PROXY_HOST" ]]; then
         echo "IP: $IP"
     fi
 
+    # if PROXY_CA_FILE is set and does not exist..
+    if [[ -n "$PROXY_CA_FILE" ]] && [ ! -f $PROXY_CA_FILE ]; then
+        if [[ -n "$PROXY_CA_URL" ]]; then
+            # Get CA via specified URL
+            until $(curl --output /dev/null --silent --head --fail "$PROXY_HOST:$PROXY_PORT"); do
+                printf 'Waiting for proxy...'
+                sleep 1
+            done
+
+            curl -x "$PROXY_HOST:$PROXY_PORT"  "$PROXY_CA_URL" > $PROXY_CA_FILE
+        fi
+    fi
+
     export http_proxy=http://$PROXY_HOST:$PROXY_PORT
     export https_proxy=http://$PROXY_HOST:$PROXY_PORT
 fi

--- a/browser_entrypoint.sh
+++ b/browser_entrypoint.sh
@@ -1,23 +1,22 @@
 #!/bin/bash
 
-if [[ -n "$PROXY_HOST" ]]; then
+if [[ -n "$PROXY_HOST" && -n "$PROXY_PORT" ]]; then
     # resolve to ip now, if possible
-    IP=$(host $PROXY_HOST | head -n 1 | cut -d ' ' -f 4)
-    if (( $? == 0 )); then
+    if IP=$(host "$PROXY_HOST" | head -n 1 | cut -d ' ' -f 4); then
         export PROXY_HOST=$IP
         echo "IP: $IP"
     fi
 
     # if PROXY_CA_FILE is set and does not exist..
-    if [[ -n "$PROXY_CA_FILE" ]] && [ ! -f $PROXY_CA_FILE ]; then
+    if [[ -n "$PROXY_CA_FILE" ]] && [ ! -f "$PROXY_CA_FILE" ]; then
         if [[ -n "$PROXY_CA_URL" ]]; then
             # Get CA via specified URL
-            until $(curl --output /dev/null --silent --head --fail "$PROXY_HOST:$PROXY_PORT"); do
+            until curl --output /dev/null --silent --head --fail "$PROXY_HOST:$PROXY_PORT"; do
                 printf 'Waiting for proxy...'
                 sleep 1
             done
 
-            curl -x "$PROXY_HOST:$PROXY_PORT"  "$PROXY_CA_URL" > $PROXY_CA_FILE
+            curl -x "$PROXY_HOST:$PROXY_PORT"  "$PROXY_CA_URL" > "$PROXY_CA_FILE"
         fi
     fi
 


### PR DESCRIPTION
- if $PROXY_CA_FILE is set and exists as a file, use that as the CA cert
- if $PROXY_CA_FILE and $PROXY_CA_URL are set, curl $PROXY_CA_URL and store at $PROXY_CA_FILE,
waiting for $PROXY_HOST:$PROXY_PORT to become available